### PR TITLE
fix mobile nav anchor handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,8 +77,10 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
                 block: 'start'
             });
             // Close mobile menu if open
-            nav.classList.remove('active');
-            burger.classList.remove('active');
+            if (nav && burger) {
+                nav.classList.remove('active');
+                burger.classList.remove('active');
+            }
         }
     });
 });


### PR DESCRIPTION
## Summary
- guard mobile nav toggle in anchor click handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c71125e88331a0092640ae782180